### PR TITLE
Add : preload stylesheet and script

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,9 +7,9 @@
 
     <title>Hello!</title>
     
-    <link rel="stylesheet" href="./style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    
+    <link rel="preload" href="./script.js" as="script">
+    <link rel="preload" href="./style.css" as="style" onload="this.rel = 'stylesheet'">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" as="style" onload="this.rel='stylesheet'">
   </head>  
   <body>
       <ul class="navbar">


### PR DESCRIPTION
This pull request updates resource loading in `src/index.html` to optimize performance by preloading scripts and stylesheets. The most important change is the switch from direct stylesheet linking to using `preload` with an `onload` handler, which can improve page load speed.

Performance optimizations:

* Changed stylesheet and font icon loading to use `<link rel="preload" ... onload="this.rel='stylesheet'">` instead of direct `<link rel="stylesheet" ...>`, enabling browsers to fetch resources earlier and apply them once loaded.
* Added preloading for `script.js` to ensure the script is fetched earlier in the page load process.
* Before add this page load time is 288ms (chrome localhost) After is 259ms